### PR TITLE
Correcting Mispelling

### DIFF
--- a/lib/ui/cupertino/CupertinoActionSheetExample.dart
+++ b/lib/ui/cupertino/CupertinoActionSheetExample.dart
@@ -24,7 +24,7 @@ class CupertinoActionSheetExample extends StatelessWidget {
             Center(child: Text("First Action")),
             Center(child: Text("Second Action")),
           ],
-          cancelButton: Center(child: Text("Cancle")),
+          cancelButton: Center(child: Text("Cancel")),
         ),
       ),
     );


### PR DESCRIPTION
In "CupertinoActionSheetExample.dart" file, the cancel Button text of the action should be "Cancel" not "Cancle". Found it using the app :D